### PR TITLE
feature: Add target center, target ratio, and area tolerance to largest interior rectangle

### DIFF
--- a/ext/performance_comparison/performance_comparison.py
+++ b/ext/performance_comparison/performance_comparison.py
@@ -8,9 +8,8 @@ import matplotlib.ticker as ticker
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import lir_within_outline  # noqa: F401, E402
-
 import lir  # noqa: F401, E402
+import lir_within_outline  # noqa: F401, E402
 
 # %%
 

--- a/ext/performance_comparison/performance_comparison.py
+++ b/ext/performance_comparison/performance_comparison.py
@@ -8,8 +8,9 @@ import matplotlib.ticker as ticker
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import lir  # noqa: F401, E402
 import lir_within_outline  # noqa: F401, E402
+
+import lir  # noqa: F401, E402
 
 # %%
 

--- a/largestinteriorrectangle/__init__.py
+++ b/largestinteriorrectangle/__init__.py
@@ -1,3 +1,3 @@
 from .lir import lir, pt1, pt2  # noqa: F401
 
-__version__ = "0.2.1"
+__version__ = "0.3.1"

--- a/largestinteriorrectangle/lir.py
+++ b/largestinteriorrectangle/lir.py
@@ -14,10 +14,12 @@ def lir(data, contour=None, target_ratio=None, target_center=None, tolerance=Non
     :param contour: (optional) 2D ndarray with shape (n, 2) containing xy
     values of a specific contour where the rectangle could start (in all directions).
     Only needed for case 1.
-    :param target_ratio: (optional) float specifying the desired width/height ratio of the rectangle.
-    The rectangle with the largest area that has a width/height ratio closest to the target_ratio is returned.
-    :param target_center: (optional) tuple of 2 floats specifying the desired center of the rectangle.
-    The rectangle with the largest area that has a center closest to the target_center is returned.
+    :param target_ratio: (optional) float specifying the desired width/height ratio
+    of the rectangle. The rectangle with the largest area that has a width/height
+    ratio closest to the target_ratio is returned.
+    :param target_center: (optional) tuple of 2 floats specifying the desired center
+    of the rectangle. The rectangle with the largest area that has a center closest
+     to the target_center is returned.
     :param tolerance: (optional) float specifying the tolerance for the target_center.
     The tolerance with the largest area are considered.
     :return: 1D ndarray with lir specification: x, y, width, height

--- a/largestinteriorrectangle/lir.py
+++ b/largestinteriorrectangle/lir.py
@@ -3,7 +3,7 @@ from .lir_within_contour import largest_interior_rectangle as lir_within_contour
 from .lir_within_polygon import largest_interior_rectangle as lir_within_polygon
 
 
-def lir(data, contour=None, target_ratio=None, target_center=None, candidates=None):
+def lir(data, contour=None, target_ratio=None, target_center=None, tolerance=None):
     """
     Computes the Largest Interior Rectangle.
     :param data: Can be
@@ -18,8 +18,8 @@ def lir(data, contour=None, target_ratio=None, target_center=None, candidates=No
     The rectangle with the largest area that has a width/height ratio closest to the target_ratio is returned.
     :param target_center: (optional) tuple of 2 floats specifying the desired center of the rectangle.
     The rectangle with the largest area that has a center closest to the target_center is returned.
-    :param candidates: (optional) int specifying the number of candidates to consider when target_center is specified.
-    The candidates with the largest area are considered.
+    :param tolerance: (optional) float specifying the tolerance for the target_center.
+    The tolerance with the largest area are considered.
     :return: 1D ndarray with lir specification: x, y, width, height
     :rtype: ndarray
     """
@@ -28,14 +28,14 @@ def lir(data, contour=None, target_ratio=None, target_center=None, candidates=No
             data,
             target_ratio=target_ratio,
             target_center=target_center,
-            candidates=candidates,
+            tolerance=tolerance,
         )
     if contour is None:
         return lir_basis(
             data,
             target_ratio=target_ratio,
             target_center=target_center,
-            candidates=candidates,
+            tolerance=tolerance,
         )
     else:
         return lir_within_contour(
@@ -43,7 +43,7 @@ def lir(data, contour=None, target_ratio=None, target_center=None, candidates=No
             contour,
             target_ratio=target_ratio,
             target_center=target_center,
-            candidates=candidates,
+            tolerance=tolerance,
         )
 
 

--- a/largestinteriorrectangle/lir.py
+++ b/largestinteriorrectangle/lir.py
@@ -3,7 +3,7 @@ from .lir_within_contour import largest_interior_rectangle as lir_within_contour
 from .lir_within_polygon import largest_interior_rectangle as lir_within_polygon
 
 
-def lir(data, contour=None, target_ratio=None):
+def lir(data, contour=None, target_ratio=None, target_center=None, candidates=None):
     """
     Computes the Largest Interior Rectangle.
     :param data: Can be
@@ -14,15 +14,21 @@ def lir(data, contour=None, target_ratio=None):
     :param contour: (optional) 2D ndarray with shape (n, 2) containing xy
     values of a specific contour where the rectangle could start (in all directions).
     Only needed for case 1.
+    :param target_ratio: (optional) float specifying the desired width/height ratio of the rectangle.
+    The rectangle with the largest area that has a width/height ratio closest to the target_ratio is returned.
+    :param target_center: (optional) tuple of 2 floats specifying the desired center of the rectangle. 
+    The rectangle with the largest area that has a center closest to the target_center is returned.
+    :param candidates: (optional) int specifying the number of candidates to consider when target_center is specified.
+    The candidates with the largest area are considered.
     :return: 1D ndarray with lir specification: x, y, width, height
     :rtype: ndarray
     """
     if len(data.shape) == 3:
-        return lir_within_polygon(data, target_ratio)
+        return lir_within_polygon(data, target_ratio, target_center, candidates)
     if contour is None:
-        return lir_basis(data, target_ratio)
+        return lir_basis(data, target_ratio, target_center, candidates)
     else:
-        return lir_within_contour(data, contour, target_ratio)
+        return lir_within_contour(data, contour, target_ratio, target_center, candidates)
 
 
 def pt1(lir):

--- a/largestinteriorrectangle/lir.py
+++ b/largestinteriorrectangle/lir.py
@@ -3,7 +3,7 @@ from .lir_within_contour import largest_interior_rectangle as lir_within_contour
 from .lir_within_polygon import largest_interior_rectangle as lir_within_polygon
 
 
-def lir(data, contour=None):
+def lir(data, contour=None, target_ratio=None):
     """
     Computes the Largest Interior Rectangle.
     :param data: Can be
@@ -18,11 +18,11 @@ def lir(data, contour=None):
     :rtype: ndarray
     """
     if len(data.shape) == 3:
-        return lir_within_polygon(data)
+        return lir_within_polygon(data, target_ratio)
     if contour is None:
-        return lir_basis(data)
+        return lir_basis(data, target_ratio)
     else:
-        return lir_within_contour(data, contour)
+        return lir_within_contour(data, contour, target_ratio)
 
 
 def pt1(lir):

--- a/largestinteriorrectangle/lir.py
+++ b/largestinteriorrectangle/lir.py
@@ -16,7 +16,7 @@ def lir(data, contour=None, target_ratio=None, target_center=None, candidates=No
     Only needed for case 1.
     :param target_ratio: (optional) float specifying the desired width/height ratio of the rectangle.
     The rectangle with the largest area that has a width/height ratio closest to the target_ratio is returned.
-    :param target_center: (optional) tuple of 2 floats specifying the desired center of the rectangle. 
+    :param target_center: (optional) tuple of 2 floats specifying the desired center of the rectangle.
     The rectangle with the largest area that has a center closest to the target_center is returned.
     :param candidates: (optional) int specifying the number of candidates to consider when target_center is specified.
     The candidates with the largest area are considered.
@@ -24,11 +24,27 @@ def lir(data, contour=None, target_ratio=None, target_center=None, candidates=No
     :rtype: ndarray
     """
     if len(data.shape) == 3:
-        return lir_within_polygon(data, target_ratio, target_center, candidates)
+        return lir_within_polygon(
+            data,
+            target_ratio=target_ratio,
+            target_center=target_center,
+            candidates=candidates,
+        )
     if contour is None:
-        return lir_basis(data, target_ratio, target_center, candidates)
+        return lir_basis(
+            data,
+            target_ratio=target_ratio,
+            target_center=target_center,
+            candidates=candidates,
+        )
     else:
-        return lir_within_contour(data, contour, target_ratio, target_center, candidates)
+        return lir_within_contour(
+            data,
+            contour,
+            target_ratio=target_ratio,
+            target_center=target_center,
+            candidates=candidates,
+        )
 
 
 def pt1(lir):

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -10,6 +10,7 @@ def largest_interior_rectangle(
     v_adjacency = vertical_adjacency(grid)
     s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
     if target_center is not None:
+        assert tolerance is not None, "tolerance must be provided when target_center is used"
         return biggest_span_in_span_map_closest_to_center(
             s_map, target_center, tolerance
         )

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -2,11 +2,13 @@ import numba as nb
 import numpy as np
 
 
-def largest_interior_rectangle(grid, target_ratio=None):
+def largest_interior_rectangle(grid, target_ratio=None, target_center=None, candidates=None):
     target_ratio = float(target_ratio) if target_ratio is not None else 0
     h_adjacency = horizontal_adjacency(grid)
     v_adjacency = vertical_adjacency(grid)
     s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
+    if target_center is not None:
+        return biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
     return biggest_span_in_span_map(s_map)
 
 
@@ -154,3 +156,26 @@ def biggest_span_in_span_map(span_map):
     y = largest_rectangle_indices[0][0]
     span = span_map[y, x]
     return np.array([x, y, span[0], span[1]], dtype=np.uint32)
+
+def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidates=1):
+    areas = span_map[:, :, 0] * span_map[:, :, 1]
+    flat_areas = areas.ravel()
+
+    assert candidates > 0, "Number of candidates must be at least 1"
+    max_areas = np.argpartition(flat_areas, -candidates)[-candidates:]
+    max_areas = max_areas[np.argsort(areas.flat[max_areas])]
+    ys, xs = np.unravel_index(max_areas, areas.shape)
+
+    ws = span_map[ys, xs, 0]
+    hs = span_map[ys, xs, 1]
+
+    # inclusive rectangle convention (matches pt2)
+    rcx = xs.astype(np.float64) + (ws - 1.0) / 2.0
+    rcy = ys.astype(np.float64) + (hs - 1.0) / 2.0
+
+    cx, cy = float(target_center[0]), float(target_center[1])
+    d2 = (rcx - cx) ** 2 + (rcy - cy) ** 2
+    i = int(np.argmin(d2))
+
+    return np.array([xs[i], ys[i], ws[i], hs[i]], dtype=np.uint32)
+

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -2,13 +2,17 @@ import numba as nb
 import numpy as np
 
 
-def largest_interior_rectangle(grid, target_ratio=None, target_center=None, candidates=None):
+def largest_interior_rectangle(
+    grid, target_ratio=None, target_center=None, candidates=None
+):
     target_ratio = float(target_ratio) if target_ratio is not None else 0
     h_adjacency = horizontal_adjacency(grid)
     v_adjacency = vertical_adjacency(grid)
     s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
     if target_center is not None:
-        return biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
+        return biggest_span_in_span_map_closest_to_center(
+            s_map, target_center, candidates
+        )
     return biggest_span_in_span_map(s_map)
 
 
@@ -24,6 +28,7 @@ def horizontal_adjacency(grid):
                 span = 0
             result[y, x] = span
     return result
+
 
 @nb.njit("uint32[:,::1](boolean[:,::1])", parallel=True, cache=True)
 def vertical_adjacency(grid):
@@ -78,11 +83,12 @@ def spans(h_vector, v_vector):
     spans = np.stack((h_vector, v_vector[::-1]), axis=1)
     return spans
 
+
 @nb.njit("uint32[:](uint32[:,:], float64)", cache=True)
 def biggest_constrained_span(spans, target_ratio):
     if len(spans) == 0:
         return np.array([0, 0], dtype=np.uint32)
-    
+
     max_area = 0
     best_w = 0
     best_h = 0
@@ -90,7 +96,7 @@ def biggest_constrained_span(spans, target_ratio):
     for i in nb.prange(len(spans)):
         W_max = spans[i, 0]
         H_max = spans[i, 1]
-        
+
         w1 = W_max
         h1 = int(w1 / target_ratio)
         if h1 > H_max:
@@ -102,10 +108,10 @@ def biggest_constrained_span(spans, target_ratio):
         if w2 > W_max:
             w2 = W_max
             h2 = int(w2 / target_ratio)
-        
+
         area1 = w1 * h1
         area2 = w2 * h2
-        
+
         if area1 > max_area:
             max_area = area1
             best_w, best_h = w1, h1
@@ -157,6 +163,7 @@ def biggest_span_in_span_map(span_map):
     span = span_map[y, x]
     return np.array([x, y, span[0], span[1]], dtype=np.uint32)
 
+
 def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidates=1):
     areas = span_map[:, :, 0] * span_map[:, :, 1]
     flat_areas = areas.ravel()
@@ -178,4 +185,3 @@ def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidat
     i = int(np.argmin(d2))
 
     return np.array([xs[i], ys[i], ws[i], hs[i]], dtype=np.uint32)
-

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -2,10 +2,11 @@ import numba as nb
 import numpy as np
 
 
-def largest_interior_rectangle(grid):
+def largest_interior_rectangle(grid, target_ratio=None):
+    target_ratio = float(target_ratio) if target_ratio is not None else 0
     h_adjacency = horizontal_adjacency(grid)
     v_adjacency = vertical_adjacency(grid)
-    s_map = span_map(grid, h_adjacency, v_adjacency)
+    s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
     return biggest_span_in_span_map(s_map)
 
 
@@ -21,7 +22,6 @@ def horizontal_adjacency(grid):
                 span = 0
             result[y, x] = span
     return result
-
 
 @nb.njit("uint32[:,::1](boolean[:,::1])", parallel=True, cache=True)
 def vertical_adjacency(grid):
@@ -76,6 +76,43 @@ def spans(h_vector, v_vector):
     spans = np.stack((h_vector, v_vector[::-1]), axis=1)
     return spans
 
+@nb.njit("uint32[:](uint32[:,:], float64)", cache=True)
+def biggest_constrained_span(spans, target_ratio):
+    if len(spans) == 0:
+        return np.array([0, 0], dtype=np.uint32)
+    
+    max_area = 0
+    best_w = 0
+    best_h = 0
+
+    for i in nb.prange(len(spans)):
+        W_max = spans[i, 0]
+        H_max = spans[i, 1]
+        
+        w1 = W_max
+        h1 = int(w1 / target_ratio)
+        if h1 > H_max:
+            h1 = H_max
+            w1 = int(h1 * target_ratio)
+
+        h2 = H_max
+        w2 = int(h2 * target_ratio)
+        if w2 > W_max:
+            w2 = W_max
+            h2 = int(w2 / target_ratio)
+        
+        area1 = w1 * h1
+        area2 = w2 * h2
+        
+        if area1 > max_area:
+            max_area = area1
+            best_w, best_h = w1, h1
+        if area2 > max_area:
+            max_area = area2
+            best_w, best_h = w2, h2
+
+    return np.array([best_w, best_h], dtype=np.uint32)
+
 
 @nb.njit("uint32[:](uint32[:,:])", cache=True)
 def biggest_span(spans):
@@ -87,11 +124,11 @@ def biggest_span(spans):
 
 
 @nb.njit(
-    "uint32[:, :, :](boolean[:,::1], uint32[:,::1], uint32[:,::1])",
+    "uint32[:, :, :](boolean[:,::1], uint32[:,::1], uint32[:,::1], float64)",
     parallel=True,
     cache=True,
 )
-def span_map(grid, h_adjacency, v_adjacency):
+def span_map(grid, h_adjacency, v_adjacency, target_ratio):
     y_values, x_values = grid.nonzero()
     span_map = np.zeros(grid.shape + (2,), dtype=np.uint32)
 
@@ -100,7 +137,10 @@ def span_map(grid, h_adjacency, v_adjacency):
         h_vec = h_vector(h_adjacency, x, y)
         v_vec = v_vector(v_adjacency, x, y)
         s = spans(h_vec, v_vec)
-        s = biggest_span(s)
+        if target_ratio > 0:
+            s = biggest_constrained_span(s, target_ratio)
+        else:
+            s = biggest_span(s)
         span_map[y, x, :] = s
 
     return span_map

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -168,6 +168,9 @@ def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidat
     areas = span_map[:, :, 0] * span_map[:, :, 1]
     flat_areas = areas.ravel()
 
+    assert candidates is not None, (
+        "Candidates must be specified when target_center is specified"
+    )
     assert candidates > 0, "Number of candidates must be at least 1"
     max_areas = np.argpartition(flat_areas, -candidates)[-candidates:]
     max_areas = max_areas[np.argsort(areas.flat[max_areas])]

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 def largest_interior_rectangle(
-    grid, target_ratio=None, target_center=None, candidates=None
+    grid, target_ratio=None, target_center=None, tolerance=None
 ):
     target_ratio = float(target_ratio) if target_ratio is not None else 0
     h_adjacency = horizontal_adjacency(grid)
@@ -11,7 +11,7 @@ def largest_interior_rectangle(
     s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
     if target_center is not None:
         return biggest_span_in_span_map_closest_to_center(
-            s_map, target_center, candidates
+            s_map, target_center, tolerance
         )
     return biggest_span_in_span_map(s_map)
 
@@ -164,17 +164,12 @@ def biggest_span_in_span_map(span_map):
     return np.array([x, y, span[0], span[1]], dtype=np.uint32)
 
 
-def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidates=1):
+def biggest_span_in_span_map_closest_to_center(span_map, target_center, tolerance=0.01):
     areas = span_map[:, :, 0] * span_map[:, :, 1]
-    flat_areas = areas.ravel()
 
-    assert candidates is not None, (
-        "Candidates must be specified when target_center is specified"
-    )
-    assert candidates > 0, "Number of candidates must be at least 1"
-    max_areas = np.argpartition(flat_areas, -candidates)[-candidates:]
-    max_areas = max_areas[np.argsort(areas.flat[max_areas])]
-    ys, xs = np.unravel_index(max_areas, areas.shape)
+    max_area = np.amax(areas)
+    threshold = max_area * (1.0 - tolerance)
+    ys, xs = np.where(areas >= threshold)
 
     ws = span_map[ys, xs, 0]
     hs = span_map[ys, xs, 1]
@@ -185,6 +180,7 @@ def biggest_span_in_span_map_closest_to_center(span_map, target_center, candidat
 
     cx, cy = float(target_center[0]), float(target_center[1])
     d2 = (rcx - cx) ** 2 + (rcy - cy) ** 2
-    i = int(np.argmin(d2))
+
+    i = np.argmin(d2)
 
     return np.array([xs[i], ys[i], ws[i], hs[i]], dtype=np.uint32)

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -10,7 +10,9 @@ def largest_interior_rectangle(
     v_adjacency = vertical_adjacency(grid)
     s_map = span_map(grid, h_adjacency, v_adjacency, target_ratio)
     if target_center is not None:
-        assert tolerance is not None, "tolerance must be provided when target_center is used"
+        assert (
+            tolerance is not None
+        ), "tolerance must be provided when target_center is used"
         return biggest_span_in_span_map_closest_to_center(
             s_map, target_center, tolerance
         )

--- a/largestinteriorrectangle/lir_basis.py
+++ b/largestinteriorrectangle/lir_basis.py
@@ -171,6 +171,10 @@ def biggest_span_in_span_map_closest_to_center(span_map, target_center, toleranc
     areas = span_map[:, :, 0] * span_map[:, :, 1]
 
     max_area = np.amax(areas)
+
+    if max_area == 0:
+        return np.array([0, 0, 0, 0], dtype=np.uint32)
+
     threshold = max_area * (1.0 - tolerance)
     ys, xs = np.where(areas >= threshold)
 

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -1,7 +1,7 @@
 import numba as nb
 import numpy as np
 
-from .lir_basis import biggest_span_in_span_map
+from .lir_basis import biggest_span_in_span_map, biggest_span_in_span_map_closest_to_center
 from .lir_basis import h_vector as h_vector_top2bottom
 from .lir_basis import horizontal_adjacency as horizontal_adjacency_left2right
 from .lir_basis import predict_vector_size, span_map, spans
@@ -9,17 +9,23 @@ from .lir_basis import v_vector as v_vector_left2right
 from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 
 
-def largest_interior_rectangle(grid, contour, target_ratio=None):
+def largest_interior_rectangle(grid, contour, target_ratio=None, target_center=None, candidates=None):
     adjacencies = adjacencies_all_directions(grid)
     contour = contour.astype("uint32", order="C")
 
     target_ratio = float(target_ratio) if target_ratio is not None else 0
 
     s_map, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
-    lir1 = biggest_span_in_span_map(s_map)
+    if target_center is not None:
+        lir1 = biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
+    else:
+        lir1 = biggest_span_in_span_map(s_map)
 
     s_map = span_map(saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio)
-    lir2 = biggest_span_in_span_map(s_map)
+    if target_center is not None:
+        lir2 = biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
+    else:
+        lir2 = biggest_span_in_span_map(s_map)
 
     lir = biggest_rectangle(lir1, lir2)
     return lir

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -13,7 +13,7 @@ from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 
 
 def largest_interior_rectangle(
-    grid, contour, target_ratio=None, target_center=None, candidates=None
+    grid, contour, target_ratio=None, target_center=None, tolerance=None
 ):
     adjacencies = adjacencies_all_directions(grid)
     contour = contour.astype("uint32", order="C")
@@ -23,7 +23,7 @@ def largest_interior_rectangle(
     s_map, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
     if target_center is not None:
         lir1 = biggest_span_in_span_map_closest_to_center(
-            s_map, target_center, candidates
+            s_map, target_center, tolerance
         )
     else:
         lir1 = biggest_span_in_span_map(s_map)
@@ -33,7 +33,7 @@ def largest_interior_rectangle(
     )
     if target_center is not None:
         lir2 = biggest_span_in_span_map_closest_to_center(
-            s_map, target_center, candidates
+            s_map, target_center, tolerance
         )
     else:
         lir2 = biggest_span_in_span_map(s_map)

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -1,7 +1,10 @@
 import numba as nb
 import numpy as np
 
-from .lir_basis import biggest_span_in_span_map, biggest_span_in_span_map_closest_to_center
+from .lir_basis import (
+    biggest_span_in_span_map,
+    biggest_span_in_span_map_closest_to_center,
+)
 from .lir_basis import h_vector as h_vector_top2bottom
 from .lir_basis import horizontal_adjacency as horizontal_adjacency_left2right
 from .lir_basis import predict_vector_size, span_map, spans
@@ -9,7 +12,9 @@ from .lir_basis import v_vector as v_vector_left2right
 from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 
 
-def largest_interior_rectangle(grid, contour, target_ratio=None, target_center=None, candidates=None):
+def largest_interior_rectangle(
+    grid, contour, target_ratio=None, target_center=None, candidates=None
+):
     adjacencies = adjacencies_all_directions(grid)
     contour = contour.astype("uint32", order="C")
 
@@ -17,13 +22,19 @@ def largest_interior_rectangle(grid, contour, target_ratio=None, target_center=N
 
     s_map, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
     if target_center is not None:
-        lir1 = biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
+        lir1 = biggest_span_in_span_map_closest_to_center(
+            s_map, target_center, candidates
+        )
     else:
         lir1 = biggest_span_in_span_map(s_map)
 
-    s_map = span_map(saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio)
+    s_map = span_map(
+        saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio
+    )
     if target_center is not None:
-        lir2 = biggest_span_in_span_map_closest_to_center(s_map, target_center, candidates)
+        lir2 = biggest_span_in_span_map_closest_to_center(
+            s_map, target_center, candidates
+        )
     else:
         lir2 = biggest_span_in_span_map(s_map)
 
@@ -199,25 +210,25 @@ def create_maps(adjacencies, contour, target_ratio):
                     if h1 > h_max:
                         h1 = h_max
                         w1 = int(h1 * target_ratio)
-                    
+
                     h2 = h_max
                     w2 = int(h2 * target_ratio)
                     if w2 > w_max:
                         w2 = w_max
                         h2 = int(w2 / target_ratio)
-                    
+
                     if w1 * h1 > span_map[y, x, 0] * span_map[y, x, 1]:
                         span_map[y, x, :] = np.array([w1, h1], "uint32")
                     if w2 * h2 > span_map[y, x, 0] * span_map[y, x, 1]:
                         span_map[y, x, :] = np.array([w2, h2], "uint32")
                 else:
-                    w,h = span_array[span_idx][0], span_array[span_idx][1]
+                    w, h = span_array[span_idx][0], span_array[span_idx][1]
                     if w * h > span_map[y, x, 0] * span_map[y, x, 1]:
                         span_map[y, x, :] = np.array([w, h], "uint32")
-                        
+
                 if n == 3 and not cell_on_contour(x, y, contour):
                     saddle_candidates_map[y, x] = True
-   
+
     return span_map, direction_map, saddle_candidates_map
 
 

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -38,7 +38,7 @@ def largest_interior_rectangle(
     else:
         lir2 = biggest_span_in_span_map(s_map)
 
-    lir = biggest_rectangle(lir1, lir2)
+    lir = choose_rectangle(lir1, lir2, target_center)
     return lir
 
 
@@ -238,3 +238,29 @@ def biggest_rectangle(*args):
         if rect[2] * rect[3] > biggest_rect[2] * biggest_rect[3]:
             biggest_rect = rect
     return biggest_rect
+
+
+def rectangle_center_distance(rect, target_center):
+    rcx = float(rect[0]) + (float(rect[2]) - 1.0) / 2.0
+    rcy = float(rect[1]) + (float(rect[3]) - 1.0) / 2.0
+    dx = rcx - float(target_center[0])
+    dy = rcy - float(target_center[1])
+    return dx * dx + dy * dy
+
+
+def choose_rectangle(rect1, rect2, target_center=None):
+    if target_center is None:
+        return biggest_rectangle(rect1, rect2)
+
+    d1 = rectangle_center_distance(rect1, target_center)
+    d2 = rectangle_center_distance(rect2, target_center)
+    if d1 < d2:
+        return rect1
+    if d2 < d1:
+        return rect2
+
+    a1 = rect1[2] * rect1[3]
+    a2 = rect2[2] * rect2[3]
+    if a1 >= a2:
+        return rect1
+    return rect2

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -13,10 +13,11 @@ def largest_interior_rectangle(grid, contour, target_ratio=None):
     adjacencies = adjacencies_all_directions(grid)
     contour = contour.astype("uint32", order="C")
 
-    s_map, _, saddle_candidates_map = create_maps(adjacencies, contour)
+    target_ratio = float(target_ratio) if target_ratio is not None else 0
+
+    s_map, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
     lir1 = biggest_span_in_span_map(s_map)
 
-    target_ratio = float(target_ratio) if target_ratio is not None else 0
     s_map = span_map(saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio)
     lir2 = biggest_span_in_span_map(s_map)
 
@@ -158,17 +159,18 @@ def cell_on_contour(x, y, contour):
 
 @nb.njit(
     "Tuple((uint32[:,:,::1], uint8[:,::1], boolean[:,::1]))"
-    "(UniTuple(uint32[:,::1], 4), uint32[:,::1])",
+    "(UniTuple(uint32[:,::1], 4), uint32[:,::1], float64)",
     parallel=True,
     cache=True,
 )
-def create_maps(adjacencies, contour):
+def create_maps(adjacencies, contour, target_ratio):
     h_left2right, h_right2left, v_top2bottom, v_bottom2top = adjacencies
 
     shape = h_left2right.shape
     span_map = np.zeros(shape + (2,), "uint32")
     direction_map = np.zeros(shape, "uint8")
     saddle_candidates_map = np.zeros(shape, "bool_")
+    constrained = target_ratio > 0
 
     for idx in nb.prange(len(contour)):
         x, y = contour[idx, 0], contour[idx, 1]
@@ -183,12 +185,33 @@ def create_maps(adjacencies, contour):
             span_array = span_arrays[direction_idx]
             for span_idx in range(span_array.shape[0]):
                 x, y = xy_array[span_idx][0], xy_array[span_idx][1]
-                w, h = span_array[span_idx][0], span_array[span_idx][1]
-                if w * h > span_map[y, x, 0] * span_map[y, x, 1]:
-                    span_map[y, x, :] = np.array([w, h], "uint32")
+                if constrained:
+                    w_max, h_max = span_array[span_idx][0], span_array[span_idx][1]
+
+                    w1 = w_max
+                    h1 = int(w1 / target_ratio)
+                    if h1 > h_max:
+                        h1 = h_max
+                        w1 = int(h1 * target_ratio)
+                    
+                    h2 = h_max
+                    w2 = int(h2 * target_ratio)
+                    if w2 > w_max:
+                        w2 = w_max
+                        h2 = int(w2 / target_ratio)
+                    
+                    if w1 * h1 > span_map[y, x, 0] * span_map[y, x, 1]:
+                        span_map[y, x, :] = np.array([w1, h1], "uint32")
+                    if w2 * h2 > span_map[y, x, 0] * span_map[y, x, 1]:
+                        span_map[y, x, :] = np.array([w2, h2], "uint32")
+                else:
+                    w,h = span_array[span_idx][0], span_array[span_idx][1]
+                    if w * h > span_map[y, x, 0] * span_map[y, x, 1]:
+                        span_map[y, x, :] = np.array([w, h], "uint32")
+                        
                 if n == 3 and not cell_on_contour(x, y, contour):
                     saddle_candidates_map[y, x] = True
-
+   
     return span_map, direction_map, saddle_candidates_map
 
 

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -9,14 +9,15 @@ from .lir_basis import v_vector as v_vector_left2right
 from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 
 
-def largest_interior_rectangle(grid, contour):
+def largest_interior_rectangle(grid, contour, target_ratio=None):
     adjacencies = adjacencies_all_directions(grid)
     contour = contour.astype("uint32", order="C")
 
     s_map, _, saddle_candidates_map = create_maps(adjacencies, contour)
     lir1 = biggest_span_in_span_map(s_map)
 
-    s_map = span_map(saddle_candidates_map, adjacencies[0], adjacencies[2])
+    target_ratio = float(target_ratio) if target_ratio is not None else 0
+    s_map = span_map(saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio)
     lir2 = biggest_span_in_span_map(s_map)
 
     lir = biggest_rectangle(lir1, lir2)

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -4,10 +4,12 @@ import numpy as np
 from .lir_basis import (
     biggest_span_in_span_map,
     biggest_span_in_span_map_closest_to_center,
+    predict_vector_size,
+    span_map,
+    spans,
 )
 from .lir_basis import h_vector as h_vector_top2bottom
 from .lir_basis import horizontal_adjacency as horizontal_adjacency_left2right
-from .lir_basis import predict_vector_size, span_map, spans
 from .lir_basis import v_vector as v_vector_left2right
 from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 
@@ -20,25 +22,26 @@ def largest_interior_rectangle(
 
     target_ratio = float(target_ratio) if target_ratio is not None else 0
 
-    s_map, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
-    if target_center is not None:
-        lir1 = biggest_span_in_span_map_closest_to_center(
-            s_map, target_center, tolerance
-        )
-    else:
-        lir1 = biggest_span_in_span_map(s_map)
+    s_map1, _, saddle_candidates_map = create_maps(adjacencies, contour, target_ratio)
 
-    s_map = span_map(
+    s_map2 = span_map(
         saddle_candidates_map, adjacencies[0], adjacencies[2], target_ratio
     )
+
+    areas1 = s_map1[:, :, 0] * s_map1[:, :, 1]
+    areas2 = s_map2[:, :, 0] * s_map2[:, :, 1]
+    mask = areas2 > areas1
+
+    s_map_combined = s_map1.copy()
+    s_map_combined[mask] = s_map2[mask]
+
     if target_center is not None:
-        lir2 = biggest_span_in_span_map_closest_to_center(
-            s_map, target_center, tolerance
+        lir = biggest_span_in_span_map_closest_to_center(
+            s_map_combined, target_center, tolerance
         )
     else:
-        lir2 = biggest_span_in_span_map(s_map)
+        lir = biggest_span_in_span_map(s_map_combined)
 
-    lir = choose_rectangle(lir1, lir2, target_center)
     return lir
 
 
@@ -142,28 +145,18 @@ def get_n_directions(spans_all_directions):
 
 
 @nb.njit(cache=True)
-def get_xy_array(x, y, spans, mode=0):
-    """0 - flip none, 1 - flip x, 2 - flip y, 3 - flip both"""
-    xy = spans.copy()
-    xy[:, 0] = x
-    xy[:, 1] = y
-    if mode == 1:
-        xy[:, 0] = xy[:, 0] - spans[:, 0] + 1
-    if mode == 2:
-        xy[:, 1] = xy[:, 1] - spans[:, 1] + 1
-    if mode == 3:
-        xy[:, 0] = xy[:, 0] - spans[:, 0] + 1
-        xy[:, 1] = xy[:, 1] - spans[:, 1] + 1
-    return xy
-
-
-@nb.njit(cache=True)
-def get_xy_arrays(x, y, spans_all_directions):
-    xy_l2r_t2b = get_xy_array(x, y, spans_all_directions[0], 0)
-    xy_r2l_t2b = get_xy_array(x, y, spans_all_directions[1], 1)
-    xy_l2r_b2t = get_xy_array(x, y, spans_all_directions[2], 2)
-    xy_r2l_b2t = get_xy_array(x, y, spans_all_directions[3], 3)
-    return xy_l2r_t2b, xy_r2l_t2b, xy_l2r_b2t, xy_r2l_b2t
+def get_top_left(x, y, w, h, direction_idx):
+    """0: none, 1: flip x, 2: flip y, 3: flip both"""
+    tx = x
+    ty = y
+    if direction_idx == 1:
+        tx = x - w + 1
+    elif direction_idx == 2:
+        ty = y - h + 1
+    elif direction_idx == 3:
+        tx = x - w + 1
+        ty = y - h + 1
+    return tx, ty
 
 
 @nb.njit(cache=True)
@@ -189,6 +182,10 @@ def create_maps(adjacencies, contour, target_ratio):
     saddle_candidates_map = np.zeros(shape, "bool_")
     constrained = target_ratio > 0
 
+    contour_grid = np.zeros(shape, "bool_")
+    for i in range(len(contour)):
+        contour_grid[contour[i, 1], contour[i, 0]] = True
+
     for idx in nb.prange(len(contour)):
         x, y = contour[idx, 0], contour[idx, 1]
         h_vectors = h_vectors_all_directions(h_left2right, h_right2left, x, y)
@@ -196,15 +193,13 @@ def create_maps(adjacencies, contour, target_ratio):
         span_arrays = spans_all_directions(h_vectors, v_vectors)
         n = get_n_directions(span_arrays)
         direction_map[y, x] = n
-        xy_arrays = get_xy_arrays(x, y, span_arrays)
+
         for direction_idx in range(4):
-            xy_array = xy_arrays[direction_idx]
             span_array = span_arrays[direction_idx]
             for span_idx in range(span_array.shape[0]):
-                x, y = xy_array[span_idx][0], xy_array[span_idx][1]
-                if constrained:
-                    w_max, h_max = span_array[span_idx][0], span_array[span_idx][1]
+                w_max, h_max = span_array[span_idx][0], span_array[span_idx][1]
 
+                if constrained:
                     w1 = w_max
                     h1 = int(w1 / target_ratio)
                     if h1 > h_max:
@@ -217,17 +212,25 @@ def create_maps(adjacencies, contour, target_ratio):
                         w2 = w_max
                         h2 = int(w2 / target_ratio)
 
-                    if w1 * h1 > span_map[y, x, 0] * span_map[y, x, 1]:
-                        span_map[y, x, :] = np.array([w1, h1], "uint32")
-                    if w2 * h2 > span_map[y, x, 0] * span_map[y, x, 1]:
-                        span_map[y, x, :] = np.array([w2, h2], "uint32")
-                else:
-                    w, h = span_array[span_idx][0], span_array[span_idx][1]
-                    if w * h > span_map[y, x, 0] * span_map[y, x, 1]:
-                        span_map[y, x, :] = np.array([w, h], "uint32")
+                    tx1, ty1 = get_top_left(x, y, w1, h1, direction_idx)
+                    if w1 * h1 > span_map[ty1, tx1, 0] * span_map[ty1, tx1, 1]:
+                        span_map[ty1, tx1, :] = np.array([w1, h1], "uint32")
 
-                if n == 3 and not cell_on_contour(x, y, contour):
-                    saddle_candidates_map[y, x] = True
+                    tx2, ty2 = get_top_left(x, y, w2, h2, direction_idx)
+                    if w2 * h2 > span_map[ty2, tx2, 0] * span_map[ty2, tx2, 1]:
+                        span_map[ty2, tx2, :] = np.array([w2, h2], "uint32")
+                else:
+                    w, h = w_max, h_max
+                    tx, ty = get_top_left(x, y, w, h, direction_idx)
+                    if w * h > span_map[ty, tx, 0] * span_map[ty, tx, 1]:
+                        span_map[ty, tx, :] = np.array([w, h], "uint32")
+
+            for dy in range(-1, 2):
+                for dx in range(-1, 2):
+                    ny, nx = y + dy, x + dx
+                    if 0 <= ny < shape[0] and 0 <= nx < shape[1]:
+                        if h_left2right[ny, nx] > 0 and not contour_grid[ny, nx]:
+                            saddle_candidates_map[ny, nx] = True
 
     return span_map, direction_map, saddle_candidates_map
 

--- a/largestinteriorrectangle/lir_within_contour.py
+++ b/largestinteriorrectangle/lir_within_contour.py
@@ -4,12 +4,10 @@ import numpy as np
 from .lir_basis import (
     biggest_span_in_span_map,
     biggest_span_in_span_map_closest_to_center,
-    predict_vector_size,
-    span_map,
-    spans,
 )
 from .lir_basis import h_vector as h_vector_top2bottom
 from .lir_basis import horizontal_adjacency as horizontal_adjacency_left2right
+from .lir_basis import predict_vector_size, span_map, spans
 from .lir_basis import v_vector as v_vector_left2right
 from .lir_basis import vertical_adjacency as vertical_adjacency_top2bottom
 

--- a/largestinteriorrectangle/lir_within_polygon.py
+++ b/largestinteriorrectangle/lir_within_polygon.py
@@ -5,7 +5,9 @@ from .lir_within_contour import largest_interior_rectangle as lir_contour
 cv = None  # as an optional dependency opencv will only be imported if needed
 
 
-def largest_interior_rectangle(polygon, target_ratio=None, target_center=None, candidates=None):
+def largest_interior_rectangle(
+    polygon, target_ratio=None, target_center=None, candidates=None
+):
     check_for_opencv()
     origin, mask = create_mask_from_polygon(polygon)
     contours, _ = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)

--- a/largestinteriorrectangle/lir_within_polygon.py
+++ b/largestinteriorrectangle/lir_within_polygon.py
@@ -5,13 +5,13 @@ from .lir_within_contour import largest_interior_rectangle as lir_contour
 cv = None  # as an optional dependency opencv will only be imported if needed
 
 
-def largest_interior_rectangle(polygon):
+def largest_interior_rectangle(polygon, target_ratio=None):
     check_for_opencv()
     origin, mask = create_mask_from_polygon(polygon)
     contours, _ = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
     contour = contours[0][:, 0, :]
     mask = mask > 0
-    lir = lir_contour(mask, contour)
+    lir = lir_contour(mask, contour, target_ratio)
     lir = lir.astype(np.int32)
     lir[0:2] = lir[0:2] + origin
     return lir

--- a/largestinteriorrectangle/lir_within_polygon.py
+++ b/largestinteriorrectangle/lir_within_polygon.py
@@ -5,13 +5,13 @@ from .lir_within_contour import largest_interior_rectangle as lir_contour
 cv = None  # as an optional dependency opencv will only be imported if needed
 
 
-def largest_interior_rectangle(polygon, target_ratio=None):
+def largest_interior_rectangle(polygon, target_ratio=None, target_center=None, candidates=None):
     check_for_opencv()
     origin, mask = create_mask_from_polygon(polygon)
     contours, _ = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
     contour = contours[0][:, 0, :]
     mask = mask > 0
-    lir = lir_contour(mask, contour, target_ratio)
+    lir = lir_contour(mask, contour, target_ratio, target_center, candidates)
     lir = lir.astype(np.int32)
     lir[0:2] = lir[0:2] + origin
     return lir

--- a/largestinteriorrectangle/lir_within_polygon.py
+++ b/largestinteriorrectangle/lir_within_polygon.py
@@ -6,14 +6,21 @@ cv = None  # as an optional dependency opencv will only be imported if needed
 
 
 def largest_interior_rectangle(
-    polygon, target_ratio=None, target_center=None, candidates=None
+    polygon, target_ratio=None, target_center=None, tolerance=None
 ):
     check_for_opencv()
     origin, mask = create_mask_from_polygon(polygon)
     contours, _ = cv.findContours(mask, cv.RETR_TREE, cv.CHAIN_APPROX_NONE)
     contour = contours[0][:, 0, :]
     mask = mask > 0
-    lir = lir_contour(mask, contour, target_ratio, target_center, candidates)
+    target_center_local = None
+    if target_center is not None:
+        target_center_local = (
+            float(target_center[0]) - float(origin[0]),
+            float(target_center[1]) - float(origin[1]),
+        )
+
+    lir = lir_contour(mask, contour, target_ratio, target_center_local, tolerance)
     lir = lir.astype(np.int32)
     lir[0:2] = lir[0:2] + origin
     return lir

--- a/tests/test_lir_basis.py
+++ b/tests/test_lir_basis.py
@@ -30,7 +30,7 @@ class TestLIRbasis(unittest.TestCase):
 
         h = lir.horizontal_adjacency(grid)
         v = lir.vertical_adjacency(grid)
-        span_map = lir.span_map(grid, h, v)
+        span_map = lir.span_map(grid, h, v, 0)
         rect = lir.biggest_span_in_span_map(span_map)
         rect2 = lir.largest_interior_rectangle(grid)
 

--- a/tests/test_lir_basis.py
+++ b/tests/test_lir_basis.py
@@ -66,6 +66,12 @@ class TestLIRbasis(unittest.TestCase):
         np.testing.assert_array_equal(rect, np.array([2, 2, 5, 2]))
         np.testing.assert_array_equal(rect, rect2)
 
+        rect3 = lir.biggest_span_in_span_map_closest_to_center(span_map, (5, 5))
+        rect4 = lir.largest_interior_rectangle(grid, target_ratio, (5, 5), 0)
+
+        np.testing.assert_array_equal(rect3, np.array([2, 4, 5, 2]))
+        np.testing.assert_array_equal(rect3, rect4)
+
     def test_spans(self):
         grid = np.array(
             [[1, 1, 1], [1, 1, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 1]]

--- a/tests/test_lir_basis.py
+++ b/tests/test_lir_basis.py
@@ -37,6 +37,35 @@ class TestLIRbasis(unittest.TestCase):
         np.testing.assert_array_equal(rect, np.array([2, 2, 4, 7]))
         np.testing.assert_array_equal(rect, rect2)
 
+    def test_constrained_lir(self):
+        grid = np.array(
+            [
+                [0, 0, 1, 0, 0, 0, 0, 0, 0],
+                [0, 0, 1, 0, 1, 1, 0, 0, 0],
+                [0, 0, 1, 1, 1, 1, 1, 0, 0],
+                [0, 0, 1, 1, 1, 1, 1, 1, 0],
+                [0, 0, 1, 1, 1, 1, 1, 1, 0],
+                [0, 1, 1, 1, 1, 1, 1, 0, 0],
+                [0, 0, 1, 1, 1, 1, 0, 0, 0],
+                [0, 0, 1, 1, 1, 1, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1, 0, 0, 0],
+                [1, 1, 0, 0, 0, 1, 1, 1, 1],
+                [0, 0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        )
+        grid = grid > 0
+
+        target_ratio = 2
+
+        h = lir.horizontal_adjacency(grid)
+        v = lir.vertical_adjacency(grid)
+        span_map = lir.span_map(grid, h, v, target_ratio)
+        rect = lir.biggest_span_in_span_map(span_map)
+        rect2 = lir.largest_interior_rectangle(grid, target_ratio)
+
+        np.testing.assert_array_equal(rect, np.array([2, 2, 5, 2]))
+        np.testing.assert_array_equal(rect, rect2)
+
     def test_spans(self):
         grid = np.array(
             [[1, 1, 1], [1, 1, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 1]]


### PR DESCRIPTION
This PR addresses #29 by enhancing the largest_interior_rectangle algorithm to provide better control over result shape and positioning.

Aspect Ratio Support: Updated `biggest_constrained_span `to support a `target_ratio `constraint, allowing for width-to-height filtering.

Target Center Bias: Added `target_center ` support to prioritize rectangles closer to a specific point.

Implemented `tolerance ` in `biggest_span_in_span_map_closest_to_center`. This allows the algorithm to select from the top areas (within a percentage of max area) to find the one best aligned with the target center.